### PR TITLE
additional ChromeDriver option to make it run in Docker

### DIFF
--- a/pdf_with_js/printer.py
+++ b/pdf_with_js/printer.py
@@ -86,6 +86,8 @@ class Printer():
         webdriver_options = Options()
         webdriver_options.add_argument('--headless')
         webdriver_options.add_argument('--disable-gpu')
+        webdriver_options.add_argument('--no-sandbox')
+        webdriver_options.add_argument('--disable-dev-shm-usage')
         return webdriver.Chrome(options=webdriver_options)
 
     def _set_print_options(self):


### PR DESCRIPTION
For creating the PDFs the chromedriver is used. Without the added otpions the chromedriver was unable to open and the following error occurred:
`unknown error: DevToolsActivePort file doesn't exist`